### PR TITLE
changes to enable debugging openocd

### DIFF
--- a/example/pico-hello-world/firmware.c
+++ b/example/pico-hello-world/firmware.c
@@ -7,14 +7,14 @@
 int
 main(void)
 {
-    // Enable USB-UART #0 output
-    stdio_init_all();
 
     // Init the pico-ice-sdk library
     ice_init();
 
+    // Enable USB-UART #0 output
+    stdio_init_all();
+    
     // Setup code here.
-
     for (;;) {
         ice_usb_task();
 


### PR DESCRIPTION
there is some initialization happening in ice_init which was not working with stdio_init_all , the order mattered. If not done, debugger stops in a force break-point.  

Tested with DEBUG and RELEASE and both UF2 files worked on pico-ice